### PR TITLE
request to add my gc_spyu

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The users of Golem run the reference implementation in the form of the Rust impl
 - [Golem Image Sharpening](https://github.com/visualNext/golem) - A tool to sharpen images.
 - [Filterms](https://github.com/krunch3r76/filterms) - Market-strategy for whitelisting or blacklisting as a Golem requestor (yapapi).
 - [golem-bulk-image-handler](https://github.com/figurestudios/golem-bulk-image-handler) - Takes an input image and processes it in many different ways using the Pillow library.
+- [gc_spyu] (https://github.com/krunch3r76/gc_spyu) - Obtain cpu speeds of specific providers and integrate results with gc_listoffers
 
 ## Bounties and Rewards
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The users of Golem run the reference implementation in the form of the Rust impl
 - [Golem Image Sharpening](https://github.com/visualNext/golem) - A tool to sharpen images.
 - [Filterms](https://github.com/krunch3r76/filterms) - Market-strategy for whitelisting or blacklisting as a Golem requestor (yapapi).
 - [golem-bulk-image-handler](https://github.com/figurestudios/golem-bulk-image-handler) - Takes an input image and processes it in many different ways using the Pillow library.
-- [gc_spyu] (https://github.com/krunch3r76/gc_spyu) - Obtain cpu speeds of specific providers and integrate results with gc_listoffers
+- [gc_spyu](https://github.com/krunch3r76/gc_spyu) - Obtain cpu speeds of specific providers and integrate results with gc__listoffers
 
 ## Bounties and Rewards
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The users of Golem run the reference implementation in the form of the Rust impl
 - [Golem Image Sharpening](https://github.com/visualNext/golem) - A tool to sharpen images.
 - [Filterms](https://github.com/krunch3r76/filterms) - Market-strategy for whitelisting or blacklisting as a Golem requestor (yapapi).
 - [golem-bulk-image-handler](https://github.com/figurestudios/golem-bulk-image-handler) - Takes an input image and processes it in many different ways using the Pillow library.
-- [gc_spyu](https://github.com/krunch3r76/gc_spyu) - Obtain cpu speeds of specific providers and integrate results with gc__listoffers
+- [gc_spyu](https://github.com/krunch3r76/gc_spyu) - Obtain cpu speeds of specific providers and integrate results with gc__listoffers.
 
 ## Bounties and Rewards
 


### PR DESCRIPTION
gc_spyu is a requestor task app that on its own can do more than golem's yapapi's upcoming scanner api by providing a CLI to obtain specific provider cpu speed information. additionally, it provides more information than the modelname which is expected to be available from the next yagna version by adding speed information. in other words, awesome.